### PR TITLE
Behat test failure fix

### DIFF
--- a/bootstrap/FeatureContext.php
+++ b/bootstrap/FeatureContext.php
@@ -537,9 +537,9 @@ class FeatureContext extends MinkContext {
 	/**
 	 * Wordpress: Verifies if plugin is network activated from Network Admin Plugins page
 	 *
-	 * @Then /^"([^"]*)" plugin is network activated$/
+	 * @Then /^"([^"]*)" plugin is installed and network activated$/
 	 */
-	public function pluginIsNetworkActivated( $pluginName ) {
+	public function pluginIsInstalledAndNetworkActivated( $pluginName ) {
 		$this->pluginIsInstalled( $pluginName );
 		$pluginactivationfield = $this->getSession()->getPage()->find( 'css', 'td[class="plugin-title column-primary"]' );
 		$pluginInfo            = $pluginactivationfield->getText();

--- a/features/plugins/avatarsForMultisite.feature
+++ b/features/plugins/avatarsForMultisite.feature
@@ -3,7 +3,7 @@ Feature: As a network admin, I verify if Avatars for Multisite is installed, net
 
 Scenario: Verify if Avatars for Multisite is installed and network activated
 	Given I am logged in as "localsuperbehat"
-	Then "Avatars For Multisite" plugin is installed
+	#Then "Avatars For Multisite" plugin is installed
 	Then "Avatars For Multisite" plugin is network activated
 	Then I log out
 

--- a/features/plugins/avatarsForMultisite.feature
+++ b/features/plugins/avatarsForMultisite.feature
@@ -4,7 +4,7 @@ Feature: As a network admin, I verify if Avatars for Multisite is installed, net
 Scenario: Verify if Avatars for Multisite is installed and network activated
 	Given I am logged in as "localsuperbehat"
 	#Then "Avatars For Multisite" plugin is installed
-	Then "Avatars For Multisite" plugin is network activated
+	Then "Avatars For Multisite" plugin is installed and network activated
 	Then I log out
 
 Scenario: Verify the functionality 

--- a/features/plugins/customAddUser.feature
+++ b/features/plugins/customAddUser.feature
@@ -3,8 +3,8 @@ Feature: As a super admin I should verify if Custom Add User Plugin is network a
 
   Scenario: Verify if Custom Add User is Installed and Network Activated
     Given I am logged in as "localsuperbehat"
-    Then "Custom Add User" plugin is installed
-    Then "Custom Add User" plugin is network activated
+    #Then "Custom Add User" plugin is installed
+    Then "Custom Add User" plugin is installed and network activated
     Then I log out
 
   Scenario: Verify whether the Add New User form loads correctly and user gets added.

--- a/features/plugins/defaultTheme.feature
+++ b/features/plugins/defaultTheme.feature
@@ -3,8 +3,8 @@ Feature: As a super admin, I verify whether Default Theme plugin is installed, n
 
 Scenario: Verify whether Default Theme Plugin is installed and Network Activated
   Given I am logged in as "localsuperbehat"
-  Then "Default Theme" plugin is installed
-  Then "Default Theme" plugin is network activated
+  #Then "Default Theme" plugin is installed
+  Then "Default Theme" plugin is installed and network activated
 
   # Check NYU Configuration (Network Admin Settings)
   Then I should visit "wp-admin/network/settings.php"

--- a/features/plugins/easyFancyBox.feature
+++ b/features/plugins/easyFancyBox.feature
@@ -3,8 +3,8 @@ Feature: As an admin I verify if easyFancyBox is installed, network activated an
 
 Scenario: Verify if Easy FancyBox is installed and network activated
 	Given I am logged in as "localsuperbehat"
-	Then "Easy FancyBox" plugin is installed
-	Then "Easy FancyBox" plugin is network activated
+	#Then "Easy FancyBox" plugin is installed
+	Then "Easy FancyBox" plugin is installed and network activated
 	Then I log out
 
 Scenario: Check NYU configuration

--- a/features/plugins/fixForBBPress.feature
+++ b/features/plugins/fixForBBPress.feature
@@ -3,6 +3,6 @@ Feature: As a super admin, I verify if Fix for bbPRess plugin is installed and n
 
 Scenario: Fix for bbPRess plugin is installed and network activated so that bbPress plugin is not affected by other plugins.
   Given I am logged in as "localsuperbehat"
-  Then "Fix for bbPress" plugin is installed
-  Then "Fix for bbPRess" plugin is network activated
+  #Then "Fix for bbPress" plugin is installed
+  Then "Fix for bbPRess" plugin is installed and network activated
   Then I log out

--- a/features/plugins/moduleControlForJetpack.feature
+++ b/features/plugins/moduleControlForJetpack.feature
@@ -3,7 +3,7 @@ Feature: As a network admin I verify if module control for jetpack is installed,
 
 Scenario: Module control for Jetpack is installed, network activated and check functionality
 	Given I am logged in as "localsuperbehat"
-	Then "Module Control for Jetpack" plugin is installed
+	#Then "Module Control for Jetpack" plugin is installed
 	Then "Module Control for Jetpack" plugin is network activated
 	Then I should visit "wp-admin/network/settings.php"
 	Then I should see "Jetpack Module Control"

--- a/features/plugins/moduleControlForJetpack.feature
+++ b/features/plugins/moduleControlForJetpack.feature
@@ -4,7 +4,7 @@ Feature: As a network admin I verify if module control for jetpack is installed,
 Scenario: Module control for Jetpack is installed, network activated and check functionality
 	Given I am logged in as "localsuperbehat"
 	#Then "Module Control for Jetpack" plugin is installed
-	Then "Module Control for Jetpack" plugin is network activated
+	Then "Module Control for Jetpack" plugin is installed and network activated
 	Then I should visit "wp-admin/network/settings.php"
 	Then I should see "Jetpack Module Control"
 	# Verify is Subsite Override is OFF to not allow individual site administrators

--- a/features/plugins/multiSiteThemeManager.feature
+++ b/features/plugins/multiSiteThemeManager.feature
@@ -3,8 +3,8 @@ Feature: As a super admin I should verify if Multisite Theme Manager Plugin is i
 
   Scenario: Verify if Multisite Theme Manager is Installed and Network Activated
     Given I am logged in as "localsuperbehat"
-    Then "Multisite Theme Manager" plugin is installed
-    Then "Multisite Theme Manager" plugin is network activated
+    #Then "Multisite Theme Manager" plugin is installed
+    Then "Multisite Theme Manager" plugin is installed and network activated
     Then I log out
 
   Scenario: Multisite Theme Manager is visible on Sidebar and NYU configuration is set

--- a/features/plugins/newBlogTemplates.feature
+++ b/features/plugins/newBlogTemplates.feature
@@ -4,7 +4,7 @@ Feature: As a user I should be able to create new site using newBlogTemplate Plu
   @javascript
   Scenario: Verify New Blog Templates is installed and Network Activated
     Given I am logged in as "localsuperbehat"
-    Then "New Blog Templates" plugin is installed
+    #Then "New Blog Templates" plugin is installed
     Then "New Blog Templates" plugin is network activated
     Then I log out
 

--- a/features/plugins/newBlogTemplates.feature
+++ b/features/plugins/newBlogTemplates.feature
@@ -5,7 +5,7 @@ Feature: As a user I should be able to create new site using newBlogTemplate Plu
   Scenario: Verify New Blog Templates is installed and Network Activated
     Given I am logged in as "localsuperbehat"
     #Then "New Blog Templates" plugin is installed
-    Then "New Blog Templates" plugin is network activated
+    Then "New Blog Templates" plugin is installed and network activated
     Then I log out
 
   @javascript

--- a/features/plugins/nyuStreamEmbed.feature
+++ b/features/plugins/nyuStreamEmbed.feature
@@ -3,7 +3,7 @@ Feature: As a super admin, I verify if NYU Stream Embed is installed, network ac
 
 Scenario: Verify if NYU Stream plugin is Installed and Network Activated
 	Given I am logged in as "localsuperbehat"
-	Then "NYU Stream Embed" plugin is installed
+	#Then "NYU Stream Embed" plugin is installed
 	Then "NYU Stream Embed" plugin is network activated
 
 	# NYU Stream Embed is visible on Sidebar and NYU Configuration is set

--- a/features/plugins/nyuStreamEmbed.feature
+++ b/features/plugins/nyuStreamEmbed.feature
@@ -4,7 +4,7 @@ Feature: As a super admin, I verify if NYU Stream Embed is installed, network ac
 Scenario: Verify if NYU Stream plugin is Installed and Network Activated
 	Given I am logged in as "localsuperbehat"
 	#Then "NYU Stream Embed" plugin is installed
-	Then "NYU Stream Embed" plugin is network activated
+	Then "NYU Stream Embed" plugin is installed and network activated
 
 	# NYU Stream Embed is visible on Sidebar and NYU Configuration is set
 	Then I should visit "wp-admin/network/settings.php"

--- a/features/plugins/prettyPlugins.feature
+++ b/features/plugins/prettyPlugins.feature
@@ -3,8 +3,8 @@ Feature: As a super admin, I verify if Pretty Plugins is installed, NYU configur
 
 Scenario: Verify if Pretty Plugins is Installed and Network Activated
 	Given I am logged in as "localsuperbehat"
-	Then "Pretty Plugins" plugin is installed
-	Then "Pretty Plugins" plugin is network activated
+	#Then "Pretty Plugins" plugin is installed
+	Then "Pretty Plugins" plugin is installed and network activated
 	Then I log out
 
 Scenario: Pretty Plugins is visible on Sidebar and NYU Configuration is set

--- a/features/plugins/siteSetupWizard.feature
+++ b/features/plugins/siteSetupWizard.feature
@@ -4,8 +4,8 @@ Feature: As a user I should be able to create new site using Site Setup Wizard P
   @verifyNetworkSettings
   Scenario: Verify Site Setup Wizard Plugin is installed and Network Activated
     Given I am logged in as "localsuperbehat"
-    Then "Site Setup Wizard" plugin is installed
-    Then "Site Setup Wizard" plugin is network activated
+    #Then "Site Setup Wizard" plugin is installed
+    Then "Site Setup Wizard" plugin is installed and network activated
     Then I log out
 
   @createSite

--- a/features/plugins/wpSmush.feature
+++ b/features/plugins/wpSmush.feature
@@ -3,8 +3,8 @@ Feature: As a super admin I should verify if WP Smush Plugin is network activate
 
 Scenario: WP Smush is installed, network activated, visible on Sidebar and verify NYU configuration
   Given I am logged in as "localsuperbehat"
-  Then "WP Smush Pro" plugin is installed
-  Then "WP Smush Pro" plugin is network activated
+  #Then "WP Smush Pro" plugin is installed
+  Then "WP Smush Pro" plugin is installed and network activated
 
   # Check network settings
   Then I should visit "wp-admin/network/settings.php"

--- a/features/topsites/topsites3.feature
+++ b/features/topsites/topsites3.feature
@@ -10,7 +10,7 @@ Feature: Topsites work
   Scenario: hr-nyubenefitsguide resolves
     Given I am logged in as "localsuperbehat"
     Then I should visit "hr-nyubenefitsguide"
-    Then I should see "Benefits Overview Guide"
+    Then I should see "Benefits Guides"
     Then I log out
 
   Scenario: itsecurity resolves


### PR DESCRIPTION
1. The "plugin is network activated" step already checks whether the plugin is installed. This step has been commented for  the following plugins: Avatars for Multisite, Module Control forJetpack, New Blog templates and NYU Stream Embed. The plugin is installed step can be removed later

2. Changed text Benefits Overview Guide -> Benefits Guides