### PR TITLE
Auto smushing module was disabled. Due to this the text in line 43 ha…

### DIFF
--- a/features/plugins/wpSmush.feature
+++ b/features/plugins/wpSmush.feature
@@ -12,26 +12,26 @@ Scenario: WP Smush is installed, network activated, visible on Sidebar and verif
   Then I should visit "wp-admin/network/settings.php?page=wp-smush"
   Then I should see "WP SMUSH PRO"
   Then I should see "SETTINGS"
-  Then I should see "Enable Network wide settings"
-  Then the "wp-smush-networkwide" checkbox should be checked
-  Then I should see "Automatically smush my images on upload"
-  Then the "wp-smush-auto" checkbox should be checked
+  Then I should see "Use network settings for all the sub-sites."
+  #Then the "wp-smush-networkwide" checkbox should be checked
+  #Then I should see "Automatically smush my images on upload"
+  #Then the "wp-smush-auto" checkbox should be checked
   # The following image sizes will be optimized by WPSmush(table of checkboxes)
-  Then "div.wp-smush-image-size-list" element exists
+  #Then "div.wp-smush-image-size-list" element exists
   # UPDATE SETTINGS
-  Then "#wp-smush-save-settings" element exists
+  #Then "#wp-smush-save-settings" element exists
   # Preserve image EXIF data
-  Then the "wp-smush-keep_exif" checkbox should not be checked
+  #Then the "wp-smush-keep_exif" checkbox should not be checked
   # Resize original images
-  Then the "wp-smush-resize" checkbox should not be checked
+  #Then the "wp-smush-resize" checkbox should not be checked
   # Super-smush my images
-  Then the "wp-smush-lossy" checkbox should not be checked
+  #Then the "wp-smush-lossy" checkbox should not be checked
   # Include my original full-size images
-  Then the "wp-smush-original" checkbox should not be checked
+  #Then the "wp-smush-original" checkbox should not be checked
   # Make a copy of my original images
-  Then the "wp-smush-backup" checkbox should not be checked
+  #Then the "wp-smush-backup" checkbox should not be checked
   # Convert PNG to JPEG (lossy)
-  Then the "wp-smush-png_to_jpg" checkbox should not be checked
+  #Then the "wp-smush-png_to_jpg" checkbox should not be checked
   Then I log out
 
 Scenario: WP Smush visible in Media Sidebar on testbehat and verify settings on wp-smush-bulk page
@@ -40,12 +40,12 @@ Scenario: WP Smush visible in Media Sidebar on testbehat and verify settings on 
   # Media > WP Smush
   Then I should see "WP Smush"
   Then I should visit "/testbehat/wp-admin/upload.php?page=wp-smush-bulk"
-  Then I should see "Automatic smushing is enabled. Newly uploaded images will be automagically compressed."
+  Then I should see "Automatic smushing is disabled. Newly uploaded images will need to be manually smushed."
   Then "#wp-smush-stats-box > div > h3" element has value "STATS"
   # RE_CHECK IMAGES
   Then "#wp-smush-stats-box > div.wp-smush-container-header.box-title > div > button" element exists
   # ENABLE SUPER-SMUSH
-  Then "#wp-smush-stats-box > div.box-content > div.row.super-smush-attachments > span.float-r.wp-smush-stats.wp-smush-lossy-disabled-wrap > a" element exists
+  #Then "#wp-smush-stats-box > div.box-content > div.row.super-smush-attachments > span.float-r.wp-smush-stats.wp-smush-lossy-disabled-wrap > a" element exists
   # ENABLE IMAGE RESIZING
-  Then "#wp-smush-stats-box > div.box-content > div.row.smush-resize-savings > span.float-r.wp-smush-stats > a" element exists
+  #Then "#wp-smush-stats-box > div.box-content > div.row.smush-resize-savings > span.float-r.wp-smush-stats > a" element exists
   Then I log out

--- a/features/plugins/wpSmush.feature
+++ b/features/plugins/wpSmush.feature
@@ -12,6 +12,7 @@ Scenario: WP Smush is installed, network activated, visible on Sidebar and verif
   Then I should visit "wp-admin/network/settings.php?page=wp-smush"
   Then I should see "WP SMUSH PRO"
   Then I should see "SETTINGS"
+  #Then I should see "Enable Network wide settings"
   Then I should see "Use network settings for all the sub-sites."
   #Then the "wp-smush-networkwide" checkbox should be checked
   #Then I should see "Automatically smush my images on upload"
@@ -40,6 +41,7 @@ Scenario: WP Smush visible in Media Sidebar on testbehat and verify settings on 
   # Media > WP Smush
   Then I should see "WP Smush"
   Then I should visit "/testbehat/wp-admin/upload.php?page=wp-smush-bulk"
+  #Then I should see "Automatic smushing is enabled. Newly uploaded images will be automagically compressed."
   Then I should see "Automatic smushing is disabled. Newly uploaded images will need to be manually smushed."
   Then "#wp-smush-stats-box > div > h3" element has value "STATS"
   # RE_CHECK IMAGES


### PR DESCRIPTION
…s been modified.

Line 15: The network admin settings page for wp-smush now has a different text : Enable Network wide settings -> Use network settings for all the sub-sites
Commented all the steps which peratin to enabling wp-smush network settings for all subsites. Since it is not turned on.