### PR TITLE
removed the sentence: '	Then I should visit "testbehat/jetpack-test-p…

### DIFF
--- a/bootstrap/FeatureContext.php
+++ b/bootstrap/FeatureContext.php
@@ -245,6 +245,7 @@ class FeatureContext extends MinkContext {
 	 * @Then /^"([^"]*)" element exists$/
 	 */
 	public function elementExists( $element ) {
+		$this->iWaitForElement($element);
 		$selector = $this->getSession()->getPage()->find( 'css', $element );
 		if ( null === $selector ) {
 			throw new \Exception( sprintf( 'Cannot find the element ' . $element ) );

--- a/features/plugins/jetpackModules.feature
+++ b/features/plugins/jetpackModules.feature
@@ -13,7 +13,6 @@ Scenario: Verify the functionality of all Jetpack Modules
 	# Image Gallery
 	Then I click "#gallery-3"
 	# Carousel viewing window
-	Then I should visit "testbehat/jetpack-test-page/#jp-carousel-68"
 	Then "body > div.jp-carousel-wrap.jp-carousel-transitions > div.jp-carousel > div.jp-carousel-slide.selected > img" element exists
 	# Image Description
 	Then "body > div.jp-carousel-wrap.jp-carousel-transitions > div.jp-carousel-info" element exists


### PR DESCRIPTION
…age/#jp-carousel-68" because the id of the image('68') is not fixed. Basically there are 3 images in the gallery on carousel test page. The goal is to just check whether the carousel viewing window appears and has all the elements (on clicking the gallery.)

modified the elementExists() function which will wait for the element to appear on the page. The image in the carousel window takes some to appear on the page.