### PR TITLE
Scrolling Issue - Lock Posts plugin checkbox not visible in the viewport

### DIFF
--- a/features/plugins/siteSetupWizard.feature
+++ b/features/plugins/siteSetupWizard.feature
@@ -38,7 +38,7 @@ Feature: As a user I should be able to create new site using Site Setup Wizard P
     Then I wait for "Admin Tools" text
 
     # Step 4
-    Then scroll to element with class "ssw-h4"
+    Then scroll to element with class "ssw-header-wrapper"
     Then I check "Lock Posts"
     Then I check "TumblrWidget"
     Then I press "Finish"


### PR DESCRIPTION
On scrolling to the element which contains title "FEATURES" on the wpnyu.edu/create page; all the checkboxes become visible. Initially, the test scrolled to a position where the Lock Posts checkbox was not visible in the viewport.

Site Setup Wizard Stage: Start -> Essential Settings -> Themes -> Features